### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A [MCP(Model Context Protocol)](https://www.anthropic.com/news/model-context-protocol) server for accessing Slack API. This server allows AI assistants to interact with the Slack API through a standardized interface.
 
+<a href="https://glama.ai/mcp/servers/@ubie-oss/slack-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ubie-oss/slack-mcp-server/badge" alt="Slack Server MCP server" />
+</a>
+
 ## Features
 
 Available tools:


### PR DESCRIPTION
This PR adds a badge for the [Slack MCP Server](https://glama.ai/mcp/servers/@ubie-oss/slack-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ubie-oss/slack-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ubie-oss/slack-mcp-server/badge" alt="Slack Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.