### PR TITLE
Make it possible to get message even when user is null

### DIFF
--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -52,7 +52,7 @@ const ConversationsHistoryMessageSchema = z
     thread_ts: z.string().optional(),
     ts: z.string().optional(),
     type: z.string().optional(),
-    user: z.string().optional(),
+    user: z.string().nullable().optional(),
   })
   .strip();
 
@@ -90,7 +90,7 @@ const SearchMessageSchema = z
     text: z.string().optional(),
     ts: z.string().optional(),
     type: z.string().optional(),
-    user: z.string().optional(),
+    user: z.string().nullable().optional(),
   })
   .strip();
 


### PR DESCRIPTION
Sometimes the "user" field is null when fetching messages from Slack.  
(This may happen with older webhook formats.)  
  
When this happens, slack_search_messages can fail with an error like this:  
```
Error handling request: ZodError: [ { "code": "invalid_type", "expected": "string", "received": "null", "path": [ "messages", "matches", 1, "user" ], "message": "Expected string, received null" }, { "code": "invalid_type", "expected": "string", "received": "null", "path": [ "messages", "matches", 17, "user" ], "message": "Expected string, received null" }, { "code": "invalid_type", "expected": "string", "received": "null", "path": [ "messages", "matches", 47, "user" ], "message": "Expected string, received null" }
```  
  
This Pull Request makes the "user" field nullable to avoid such errors.  