### PR TITLE
fix: add email field to slack_search_users filter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -170,7 +170,7 @@ function createServer(): Server {
         {
           name: 'slack_search_users',
           description:
-            'Search for users by partial name match across username, display name, and real name. Use this when you need to find users containing specific keywords in their names. Returns up to the specified limit of matching users.',
+            'Search for users by partial match across username, display name, real name, and email. Use this when you need to find users by name or email address. Returns up to the specified limit of matching users.',
           inputSchema: zodToJsonSchema(SearchUsersRequestSchema),
         },
       ],
@@ -548,18 +548,20 @@ function createServer(): Server {
               return false;
             }
 
-            // Search across multiple name fields
+            // Search across multiple name and profile fields
             const name = user.name?.toLowerCase() || '';
             const realName = user.real_name?.toLowerCase() || '';
             const displayName = user.profile?.display_name?.toLowerCase() || '';
             const displayNameNormalized =
               user.profile?.display_name_normalized?.toLowerCase() || '';
+            const email = (user.profile?.email as string)?.toLowerCase() || '';
 
             return (
               name.includes(searchTerm) ||
               realName.includes(searchTerm) ||
               displayName.includes(searchTerm) ||
-              displayNameNormalized.includes(searchTerm)
+              displayNameNormalized.includes(searchTerm) ||
+              email.includes(searchTerm)
             );
           });
 


### PR DESCRIPTION
## Summary
- `slack_search_users` now matches against `profile.email` in addition to `name`, `real_name`, `display_name`, and `display_name_normalized`
- This allows finding users by their email address (e.g. `tsubasa.nakamura@ubie-partners.com`)

## Background
Contractors/freelancers whose email domain differs from the main org (e.g. `@ubie-partners.com`) could not be found via `slack_search_users` because the tool only searched name fields. This caused downstream workflows (n8n Activity Report generation) to fail Slack ID resolution for ~176 contractor accounts.

## Changes
- `src/index.ts`: Add `user.profile.email` to the search filter in `slack_search_users`
- Updated tool description to mention email search capability

## Test plan
- [ ] Search by full email: `tsubasa.nakamura@ubie-partners.com` → should return the user
- [ ] Search by email domain: `@ubie-partners.com` → should return matching users
- [ ] Search by name still works: `中村翼` → should return the user
- [ ] Existing name-based searches are not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)