### PR TITLE
ci: namespace npm cache by workflow in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,8 +19,18 @@ jobs:
           node-version: '20'
           registry-url: 'https://npm.pkg.github.com'
           scope: '@ubie-oss'
-          cache: 'npm'
-      
+
+      # Namespace npm cache by workflow so CI (ci.yml) and publish (publish.yml)
+      # do not share a key. This is defense in depth against a poisoned cache
+      # being restored on the publish path.
+      - name: Cache npm
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-${{ github.workflow }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ github.workflow }}-npm-
+
       - name: Install dependencies
         run: npm ci
       


### PR DESCRIPTION
## Summary

`ci.yml` (runs on every PR/push) and `publish.yml` (runs on release creation) both used `actions/setup-node`'s built-in `cache: 'npm'`, which derives the cache key from `runner.os` + `package-lock.json` hash only. The two workflows therefore share a cache key.

Replace `publish.yml`'s built-in cache with an explicit `actions/cache@v4` whose key is namespaced by `github.workflow`, so the publish path never restores a cache produced by CI.

## Why

GitHub Actions scopes cache by branch by default, so today this is safe in practice: a PR cannot poison `main`'s cache without `pull_request_target` (this repo does not use that trigger). But if `pull_request_target` is ever introduced, a PR could write to `main`'s cache scope under the shared key and the release job would happily restore it. Namespacing the publish cache removes that future foot-gun.

## Test plan
- [ ] Cut a test release on a tag; verify the publish workflow runs and produces a new namespaced cache